### PR TITLE
Tree improvements

### DIFF
--- a/app/assets/javascripts/admin/moi_tree.js.coffee
+++ b/app/assets/javascripts/admin/moi_tree.js.coffee
@@ -37,8 +37,14 @@ class moiTree.Tree
               .attr("height", @height)
               .attr('viewBox',"0 0 #{@width} #{@height}")
               .attr('preserveAspectRatio', 'xMidYMid')
+              .style("overflow", "scroll")
               .append('g')
+              .attr("class","drawarea")
               .attr('transform', 'translate(0,10)')
+    d3.select('svg').call d3.behavior.zoom().scaleExtent([
+      0.5
+      5
+    ]).on('zoom', zoom)
 
   getNeurons: ->
     d3.json @path, @gotNeurons
@@ -78,8 +84,8 @@ class moiTree.Tree
                   .enter()
                   .append("g")
                   .attr("class", "node")
-                  .attr("transform", (d) ->
-                    "translate(#{d.x},#{d.y})"
+                  .attr("transform", (d) =>
+                    "translate(#{d.x}, #{ @height - d.y})"
                   )
     neuron.append("circle")
           .attr("r", 4.5)
@@ -108,8 +114,8 @@ class moiTree.Tree
     @tree.nodes(@rootNeuron)
 
     links = @tree.links(@shownNeurons)
-    diagonal = d3.svg.diagonal().projection((d) ->
-      [ d.x, d.y ]
+    diagonal = d3.svg.diagonal().projection((d) =>
+      [ d.x, @height - d.y ]
     )
     link = @svg.selectAll("path.link")
                 .data(links)
@@ -187,6 +193,27 @@ class moiTree.Tree
 
   showDetails: (neuron, text) ->
     new moiTree.TreeDialog(neuron, text, @rootNeuron)
+
+  zoom = ->
+    $('.popover').hide()
+    @m = [40, 240, 40, 240]
+    @realWidth = window.innerWidth
+    @realHeight = window.innerHeight
+    @w = @realWidth - @m[0] - @m[0]
+    @h = @realHeight - @m[0] - @m[2]
+    scale = d3.event.scale
+    translation = d3.event.translate
+    tbound = -@h * scale
+    bbound = @h * scale
+    lbound = (-@w + @m[1]) * scale
+    rbound = (@w - @m[3]) * scale
+    # limit translation to thresholds
+    translation = [
+      Math.max(Math.min(translation[0], rbound), lbound)
+      Math.max(Math.min(translation[1], bbound), tbound)
+    ]
+    d3.select('.drawarea').attr 'transform', 'translate(' + translation + ')' + ' scale(' + scale + ')'
+    return
 
 $(document).on "ready page:load", ->
   if $("#moi_tree").length > 0

--- a/app/assets/stylesheets/admin/moi_tree.css.sass
+++ b/app/assets/stylesheets/admin/moi_tree.css.sass
@@ -1,22 +1,12 @@
 #moi_tree
-  svg
-    transform: rotate(180deg)
-    -webkit-transform: rotate(180deg)
-    -moz-transform: rotate(180deg)
-    -o-transform: rotate(180deg)
-
   .node
     circle
       fill: #fff
       stroke: steelblue
       stroke-width: 1.5px
       cursor: pointer
-      
+
     text
-      transform: rotate(180deg)
-      -webkit-transform: rotate(180deg)
-      -moz-transform: rotate(180deg)
-      -o-transform: rotate(180deg)
       cursor: pointer
       &:hover
         font-weight: bold
@@ -39,3 +29,7 @@
     position: absolute
     top: 0
     right: 2px
+
+svg
+  pointer-events: all
+  background-color: #fafafa


### PR DESCRIPTION
- Remove css in order to create a d3 tree without css transform
- Now tree grows from bottom to top naturally
- Now tree has zoom and panning
