### PR TITLE
videos include thumbnails in API

### DIFF
--- a/app/decorators/content_video_decorator.rb
+++ b/app/decorators/content_video_decorator.rb
@@ -2,15 +2,11 @@ require "uri"
 require "cgi"
 
 class ContentVideoDecorator < LittleDecorator
-  SUPPORTED_PARTIES = %w(
-    youtube
-  ).freeze
-
   def list_group_item
-    if supported_party.present?
+    if record.supported_party?
       embedded
     else
-      record.url
+      record.url_without_schema
     end
   end
 
@@ -18,43 +14,11 @@ class ContentVideoDecorator < LittleDecorator
     content_tag(
       :iframe,
       nil,
-      src: rendered_url,
+      src: record.embedded_url,
       width: 560,
       height: 315,
       frameborder: 0,
       allowfullscreen: :allowfullscreen
     )
-  end
-
-  private
-
-  def supported_party
-    @supported_party ||= SUPPORTED_PARTIES.detect do |party|
-      url.include?(party)
-    end
-  end
-
-  def url
-    @url ||=
-      begin
-        @uri = URI(record.url)
-        record.url.sub("#{@uri.scheme}:", "")
-      rescue URI::InvalidURIError
-        record.url
-      end
-  end
-
-  def rendered_url
-    send("render_#{supported_party}") || url
-  end
-
-  def render_youtube
-    if uri_params.present? && uri_params["v"]
-      "//www.youtube.com/embed/#{uri_params["v"].first}"
-    end
-  end
-
-  def uri_params
-    @uri_params ||= CGI::parse(@uri.query) if @uri.query.present?
   end
 end

--- a/app/models/concerns/content_video/embeddable.rb
+++ b/app/models/concerns/content_video/embeddable.rb
@@ -1,0 +1,58 @@
+class ContentVideo < ActiveRecord::Base
+  module Embeddable
+    SUPPORTED_PARTIES = %w(
+      youtube
+    ).freeze
+
+    def supported_party?
+      supported_party.present?
+    end
+
+    def embedded_url
+      send("embedded_#{supported_party}") || url_without_schema
+    end
+
+    def thumbnail
+      send("thumbnail_#{supported_party}") if supported_party?
+    end
+
+    def url_without_schema
+      @url_without_schema ||= if uri.present?
+          url.sub("#{uri.scheme}:", "")
+        else
+          url
+        end
+    end
+
+    private
+
+    def supported_party
+      @supported_party ||= SUPPORTED_PARTIES.detect do |party|
+        url.include?(party)
+      end
+    end
+
+    def embedded_youtube
+      if uri_params.present? && uri_params["v"]
+        "//www.youtube.com/embed/#{uri_params["v"].first}"
+      end
+    end
+
+    def thumbnail_youtube
+      if uri_params.present? && uri_params["v"]
+        "//img.youtube.com/vi/#{uri_params["v"].first}/0.jpg"
+      end
+    end
+
+    def uri_params
+      @uri_params ||= CGI::parse(
+        uri.query
+      ) if uri.try(:query).present?
+    end
+
+    def uri
+      @uri ||= URI(url)
+    rescue URI::InvalidURIError
+    end
+  end
+end

--- a/app/serializers/api/content_serializer.rb
+++ b/app/serializers/api/content_serializer.rb
@@ -46,7 +46,10 @@ module Api
     end
 
     def videos
-      object.content_videos.map(&:url)
+      ActiveModel::ArraySerializer.new(
+        object.content_videos,
+        each_serializer: ContentVideoSerializer
+      )
     end
 
     alias_method :current_user, :scope

--- a/app/serializers/api/content_video_serializer.rb
+++ b/app/serializers/api/content_video_serializer.rb
@@ -9,8 +9,9 @@
 #  updated_at :datetime         not null
 #
 
-class ContentVideo < ActiveRecord::Base
-  include Embeddable
-  belongs_to :content
-  has_paper_trail ignore: [:created_at, :updated_at, :id]
+module Api
+  class ContentVideoSerializer < ActiveModel::Serializer
+    attributes :url,
+               :thumbnail
+  end
 end

--- a/spec/decorators/content_video_decorator_spec.rb
+++ b/spec/decorators/content_video_decorator_spec.rb
@@ -13,7 +13,7 @@ describe ContentVideoDecorator do
       let(:url) { "http://domain.com" }
       it {
         expect(
-          subject.send(:url)
+          subject.send(:list_group_item)
         ).to eq("//domain.com")
       }
     end
@@ -22,7 +22,7 @@ describe ContentVideoDecorator do
       let(:url) { "bla bla bla" }
       it {
         expect(
-          subject.send(:url)
+          subject.send(:list_group_item)
         ).to eq(url)
       }
     end
@@ -34,13 +34,13 @@ describe ContentVideoDecorator do
       let(:url) {
         "https://www.youtube.com/watch?b=2&a=1&v=#{youtube_id}"
       }
-      let(:rendered_url) {
+      let(:embedded_url) {
         "//www.youtube.com/embed/#{youtube_id}"
       }
       it {
         expect(
-          subject.send(:rendered_url)
-        ).to eq(rendered_url)
+          subject.send(:embedded_url)
+        ).to eq(embedded_url)
       }
     end
   end

--- a/spec/requests/api/neurons_controller/content_videos_spec.rb
+++ b/spec/requests/api/neurons_controller/content_videos_spec.rb
@@ -15,14 +15,57 @@ RSpec.describe Api::NeuronsController,
              content: content
     }
 
-    before {
-      get "/api/neurons/#{neuron.id}"
-    }
+    describe "url" do
+      before { get "/api/neurons/#{neuron.id}" }
 
-    it {
-      expect(
-        subject["contents"].first["videos"]
-      ).to include(content_video.url)
-    }
+      it {
+        expect(
+          subject["contents"].first["videos"].first["url"]
+        ).to eq(content_video.url)
+      }
+    end
+
+    describe "thumbnail" do
+      let(:response_thumbnail) {
+        subject["contents"].first["videos"].first["thumbnail"]
+      }
+
+      describe "supported party" do
+        let(:video_id) { "VIDEOID" }
+
+        let!(:content_video) {
+          create :content_video,
+                 content: content,
+                 url: "http://youtube.com/?v=#{video_id}"
+        }
+
+        let(:thumbnail_url) {
+          "//img.youtube.com/vi/#{video_id}/0.jpg"
+        }
+
+        before { get "/api/neurons/#{neuron.id}" }
+
+        it {
+          expect(response_thumbnail).to eq(thumbnail_url)
+        }
+        it {
+          expect(response_thumbnail).to include(video_id)
+        }
+      end
+
+      describe "unsupported party" do
+        let!(:content_video) {
+          create :content_video,
+                 content: content,
+                 url: "http://provider.com/?v=id"
+        }
+
+        before { get "/api/neurons/#{neuron.id}" }
+
+        it {
+          expect(response_thumbnail).to be_nil
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
example

```
videos: [
  { url: ‘//url’,
    thumbnail: ‘//img’ },
  {..}
]
```

http://nodriza.shiriculapo.com/issues/101

**important:** to be merged before #139
